### PR TITLE
Change the ohlc close line position

### DIFF
--- a/WpfView/Points/OhlcPointView.cs
+++ b/WpfView/Points/OhlcPointView.cs
@@ -100,7 +100,7 @@ namespace LiveCharts.Wpf.Points
                 CloseLine.Y1 = Close;
                 CloseLine.Y2 = Close;
                 CloseLine.X1 = center;
-                CloseLine.X2 = Left;
+                CloseLine.X2 = Left + Width;
 
                 if (DataLabel != null)
                 {


### PR DESCRIPTION
When "DisableAnimations" is true on Chart, the ohlc close line is drawn at left of center.
Change to right side.

#### Summary
the open line and close line have been drawn at same side where is center left
This happens only when DisableAnimations" is true on Chart.

#### Solves 
The close line is better to be draw at center right.

